### PR TITLE
Add 'script' field to build args

### DIFF
--- a/anaconda_verify/const.py
+++ b/anaconda_verify/const.py
@@ -22,7 +22,7 @@ FIELDS = {
               'preserve_egg_dir', 'win_has_prefix', 'no_link',
               'ignore_prefix_files', 'msvc_compiler',
               'detect_binary_files_with_prefix',
-              'always_include_files'},
+              'always_include_files', 'script'},
     'requirements': {'build', 'run'},
     'app': {'entry', 'icon', 'summary', 'type', 'cli_opts'},
     'test': {'requires', 'commands', 'files', 'imports'},


### PR DESCRIPTION
This field is used for very simple build commands, such as when the `python setup.py install` command is uniform to all platforms.

Not having this means having to create bld.bat and build.sh for many pure-python conda recipes currently on conda-forge.
