### PR TITLE
allow new skip_compile_pyc key

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+2016-10-XX   1.2.2:
+-------------------
+  * allow skip_compile_pyc key
+
 2016-09-29   1.2.1:
 -------------------
   * fix description in setup.py

--- a/anaconda_verify/const.py
+++ b/anaconda_verify/const.py
@@ -22,7 +22,7 @@ FIELDS = {
               'preserve_egg_dir', 'win_has_prefix', 'no_link',
               'ignore_prefix_files', 'msvc_compiler',
               'detect_binary_files_with_prefix', 'script',
-              'always_include_files'},
+              'always_include_files', 'skip_compile_pyc'},
     'requirements': {'build', 'run'},
     'app': {'entry', 'icon', 'summary', 'type', 'cli_opts'},
     'test': {'requires', 'commands', 'files', 'imports'},


### PR DESCRIPTION
Hi @ilanschnell, can you review please? I left the date as 2016-10-XX incase you have other things you want to put into 1.2.2.

Prost!
